### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/CCSWE.nanoFramework.NeoPixel.Benchmarks/CCSWE.nanoFramework.NeoPixel.Benchmarks.nfproj
+++ b/CCSWE.nanoFramework.NeoPixel.Benchmarks/CCSWE.nanoFramework.NeoPixel.Benchmarks.nfproj
@@ -33,8 +33,8 @@
     <Compile Include="Reference\SampleNeoPixelStripBenchmarks.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CCSWE.nanoFramework.Math, Version=0.1.29.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.29\lib\CCSWE.nanoFramework.Math.dll</HintPath>
+    <Reference Include="CCSWE.nanoFramework.Math, Version=0.1.30.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.30\lib\CCSWE.nanoFramework.Math.dll</HintPath>
     </Reference>
     <Reference Include="Iot.Device.Ws28xx.Esp32, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\packages\nanoFramework.Iot.Device.Ws28xx.Esp32.1.2.580\lib\Iot.Device.Ws28xx.Esp32.dll</HintPath>

--- a/CCSWE.nanoFramework.NeoPixel.Benchmarks/packages.config
+++ b/CCSWE.nanoFramework.NeoPixel.Benchmarks/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CCSWE.nanoFramework.Math" version="0.1.29" targetFramework="netnano1.0" />
+  <package id="CCSWE.nanoFramework.Math" version="0.1.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.Benchmark" version="1.0.68" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.Graphics.Core" version="1.2.15" targetFramework="netnano1.0" />

--- a/CCSWE.nanoFramework.NeoPixel.Benchmarks/packages.lock.json
+++ b/CCSWE.nanoFramework.NeoPixel.Benchmarks/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETnanoFramework,Version=v1.0": {
       "CCSWE.nanoFramework.Math": {
         "type": "Direct",
-        "requested": "[0.1.29, 0.1.29]",
-        "resolved": "0.1.29",
-        "contentHash": "QQV/L/e+aScqaUst4jPM/x089GE78/zFWoGX7TV1wKpv/CtIKOYC6nINbl8UK+zJEchxVYan8DeYuC2nczcuAw=="
+        "requested": "[0.1.30, 0.1.30]",
+        "resolved": "0.1.30",
+        "contentHash": "UJvTRirfWcvIYyUd8X9aSk521cHWg1Lnhs+u2HDMkjtyToYmVvCNBRCs7fUU7hVnv6KUTP2w1Puo55cIFtn0ew=="
       },
       "nanoFramework.Benchmark": {
         "type": "Direct",

--- a/CCSWE.nanoFramework.NeoPixel.UnitTests/CCSWE.nanoFramework.NeoPixel.UnitTests.nfproj
+++ b/CCSWE.nanoFramework.NeoPixel.UnitTests/CCSWE.nanoFramework.NeoPixel.UnitTests.nfproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>

--- a/CCSWE.nanoFramework.NeoPixel.nuspec
+++ b/CCSWE.nanoFramework.NeoPixel.nuspec
@@ -18,7 +18,7 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe neopixel ws2812c</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Math" version="0.1.29" />
+      <dependency id="CCSWE.nanoFramework.Math" version="0.1.30" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.Graphics.Core" version="1.2.15" />
       <dependency id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.10" />

--- a/CCSWE.nanoFramework.NeoPixel/CCSWE.nanoFramework.NeoPixel.nfproj
+++ b/CCSWE.nanoFramework.NeoPixel/CCSWE.nanoFramework.NeoPixel.nfproj
@@ -35,8 +35,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="CCSWE.nanoFramework.Math, Version=0.1.29.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.29\lib\CCSWE.nanoFramework.Math.dll</HintPath>
+    <Reference Include="CCSWE.nanoFramework.Math, Version=0.1.30.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\CCSWE.nanoFramework.Math.0.1.30\lib\CCSWE.nanoFramework.Math.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib">
       <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>

--- a/CCSWE.nanoFramework.NeoPixel/packages.config
+++ b/CCSWE.nanoFramework.NeoPixel/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CCSWE.nanoFramework.Math" version="0.1.29" targetFramework="netnano1.0" />
+  <package id="CCSWE.nanoFramework.Math" version="0.1.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.Graphics.Core" version="1.2.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.10" targetFramework="netnano1.0" />

--- a/CCSWE.nanoFramework.NeoPixel/packages.lock.json
+++ b/CCSWE.nanoFramework.NeoPixel/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETnanoFramework,Version=v1.0": {
       "CCSWE.nanoFramework.Math": {
         "type": "Direct",
-        "requested": "[0.1.29, 0.1.29]",
-        "resolved": "0.1.29",
-        "contentHash": "QQV/L/e+aScqaUst4jPM/x089GE78/zFWoGX7TV1wKpv/CtIKOYC6nINbl8UK+zJEchxVYan8DeYuC2nczcuAw=="
+        "requested": "[0.1.30, 0.1.30]",
+        "resolved": "0.1.30",
+        "contentHash": "UJvTRirfWcvIYyUd8X9aSk521cHWg1Lnhs+u2HDMkjtyToYmVvCNBRCs7fUU7hVnv6KUTP2w1Puo55cIFtn0ew=="
       },
       "nanoFramework.CoreLibrary": {
         "type": "Direct",


### PR DESCRIPTION
Bumps CCSWE.nanoFramework.Math from 0.1.29 to 0.1.30</br>
[version update]

### :warning: This is an automated update. :warning:
