### PR TITLE
Update NeoPixel to use source clock from RMT driver

### DIFF
--- a/CCSWE.nanoFramework.NeoPixel/Drivers/NeoPixelDriver.cs
+++ b/CCSWE.nanoFramework.NeoPixel/Drivers/NeoPixelDriver.cs
@@ -1,4 +1,5 @@
 ﻿using CCSWE.nanoFramework.NeoPixel.Rmt;
+using nanoFramework.Hardware.Esp32.Rmt;
 
 namespace CCSWE.nanoFramework.NeoPixel.Drivers
 {
@@ -8,10 +9,10 @@ namespace CCSWE.nanoFramework.NeoPixel.Drivers
     public abstract class NeoPixelDriver
     {
         /// <summary>
-        /// The frequency of the APB clock used for RMT timing.
+        /// The frequency of the clock used for RMT timing.
         /// </summary>
-        /// <remarks>My understanding is that all but one ESP32 use an 80 MHz APB clock, so we'll stick with that for now.</remarks>
-        protected const float ApbClockFrequency = 80_000_000.0f; // 80 MHz
+        /// <remarks>Get frequency of clock used by RMT.</remarks>
+        protected float SourceClockFrequency = RmtChannel.SourceClockFrequency; 
 
         /// <summary>
         /// Creates the driver to provide the commands required to control the NeoPixel.
@@ -58,7 +59,7 @@ namespace CCSWE.nanoFramework.NeoPixel.Drivers
         /// <summary>
         /// The number of RMT cycles that occur in one second.
         /// </summary>
-        private float RmtCyclesPerSecond => ApbClockFrequency / ClockDivider;
+        private float RmtCyclesPerSecond => SourceClockFrequency / ClockDivider;
 
         /// <summary>
         /// The pulse data for a zero pulse (T0).


### PR DESCRIPTION
The ESP32_H2 doesn't use a 80Mhz clock but a 32Mhz clock based on its xtal.  So the neopixel doesn't work for H2 targets.

The clock frequency used by RMT has now been added as a property to RmtChannel.

The change updated NeopixelDrivers.cs to use that property instead of hard coding the 80mhz use with other devices.

 

